### PR TITLE
Add basic unit testing framework to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,45 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install tox
-        run: sudo apt-get install -y tox
+        run: sudo pip install tox
+
+      - name: Create tox environment
+        run: tox --notest
+
+      - name: Run tests
+        run: tox
+
+  unit:
+    name: Unit - ${{ matrix.py_version.name }}
+    runs-on: ubuntu-20.04
+    env:
+      TOXENV: ${{ matrix.py_version.tox_env }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        py_version:
+          - name: '3.8'
+            tox_env: unit-py38
+          - name: '3.9'
+            tox_env: unit-py39
+          - name: '3.10'
+            tox_env: unit-py310
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.py_version.name }}
+
+      - name: Output Python info
+        run: python --version --version && which python
+
+      - name: Install tox
+        run: sudo pip install tox
 
       - name: Create tox environment
         run: tox --notest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+testpaths = tests
+addopts =
+    -r a
+    --color yes
+    --showlocals
+    --verbose
+    --numprocesses auto
+    --durations 10
+    --durations-min 1
+    --strict-markers

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -1,2 +1,4 @@
 flake8
+pytest
+pytest-xdist
 yamllint

--- a/tests/unit/test_job_event.py
+++ b/tests/unit/test_job_event.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from ansible_sdk.model.job_event import BaseEvent
+
+
+class TestBaseEvent:
+
+    def test_basic(self):
+        ts = datetime(2022, 12, 31, 7, 59, 30, 1234).isoformat()
+        event = BaseEvent(event="theEvent", uuid="theUUID", counter=1,
+                          stdout="theStdout", start_line=0, end_line=10,
+                          runner_ident="theIdent", created=ts)
+
+        assert event.event == "theEvent"
+        assert event.uuid == "theUUID"
+        assert event.counter == 1
+        assert event.stdout == "theStdout"
+        assert event.start_line == 0
+        assert event.end_line == 10
+        assert event.runner_ident == "theIdent"
+        assert event.created == datetime.fromisoformat(ts)
+
+        # Test setting new created timestamp
+        new_ts = datetime(2000, 1, 17, 14, 00, 13, 5678).isoformat()
+        event.created = new_ts
+        assert event.created == datetime.fromisoformat(new_ts)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = linters
+envlist = linters, unit
 isolated_build = True
 
 [testenv]
@@ -14,3 +14,7 @@ commands =
     flake8 ansible_sdk tests
     yamllint --version
     yamllint -s .
+
+[testenv:unit{,-py38,-py39,-py310,-py311}]
+description = Run unit tests
+commands = pytest {posargs:tests/unit}


### PR DESCRIPTION
Adds support for unit testing. Also adds one simple unit test to prove validity.

We use `pip` to install tox, rather than `apt-get`, because we need a newer version to recognize Python 10 and up.

Uses the `deadsnakes` Github action, per: https://github.com/deadsnakes/action