### PR TITLE
Update GHA runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 jobs:
   sanity:
     name: ${{ matrix.test.name }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       TOXENV: ${{ matrix.test.tox_env }}
 
@@ -34,7 +34,7 @@ jobs:
 
   unit:
     name: Unit - ${{ matrix.py_version.name }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       TOXENV: ${{ matrix.py_version.tox_env }}
 


### PR DESCRIPTION
Seems that the Ubuntu 22.04 runner is now fully supported. Let's update these jobs to use the newer version.