### PR TITLE
Fix warning about asyncio.wait() usage

### DIFF
--- a/ansible_sdk/model/job_status.py
+++ b/ansible_sdk/model/job_status.py
@@ -61,7 +61,9 @@ class AnsibleJobStatus:
                 return
 
             # chill, let either done or newevent wake us up
-            await asyncio.wait([self._newevent.wait(), self._done.wait()], return_when=asyncio.FIRST_COMPLETED)
+            newevent_task = asyncio.create_task(self._newevent.wait())
+            done_task = asyncio.create_task(self._done.wait())
+            await asyncio.wait([newevent_task, done_task], return_when=asyncio.FIRST_COMPLETED)
 
     def __await__(self):
         # make the job object itself awaitable for completion


### PR DESCRIPTION
Currently seeing this warning when using the SDK:

```
/home/runner/work/ansible-sdk/ansible-sdk/ansible_sdk/model/job_status.py:64: DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.
    await asyncio.wait([self._newevent.wait(), self._done.wait()], return_when=asyncio.FIRST_COMPLETED)
```

Solution seems to be to manually wrap the coroutines in tasks.