### PR TITLE
Switch to Sphinx Ansible Theme

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,4 +25,4 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-     - requirements: docs/doc-requirements.txt
+    - requirements: docs/doc-requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/source/conf.py
+  configuration: docs/source/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:
@@ -24,5 +24,5 @@ sphinx:
 
 # Optionally declare the Python requirements required to build your docs
 python:
-   install:
-   - requirements: docs/doc-requirements.txt
+  install:
+     - requirements: docs/doc-requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,28 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/doc-requirements.txt

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,2 +1,2 @@
 Sphinx==5.1.1
-sphinx-immaterial==0.9.1
+sphinx-ansible-theme==0.9.1

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,2 +1,3 @@
 Sphinx==5.1.1
 sphinx-ansible-theme==0.9.1
+sphinxcontrib-apidoc==0.3.0

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,5 +1,7 @@
 API Reference
 =============
 
-coming soon
+.. toctree::
+
+   api/modules
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -4,4 +4,5 @@ API Reference
 .. toctree::
 
    api/modules
+   api/executors
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,5 +1,5 @@
 API Reference
 =============
 
-.. python-apigen-group:: Classes
+coming soon
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,15 +15,31 @@ release = '0.0.1'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-     'sphinx_ansible_theme',
+    'sphinx_ansible_theme',
+    'sphinxcontrib.apidoc'
 ]
 
 templates_path = ['_templates']
 exclude_patterns = []
 
+#apidoc configuration
+#find more at https://pypi.org/project/sphinxcontrib-apidoc/
+apidoc_module_dir = '../../ansible_sdk/'
+#apidoc_excluded_paths = ['tests']
+apidoc_separate_modules = True
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = "ansible"
+highlight_language = "YAML+Jinja"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'sphinx_ansible_theme'
 html_static_path = ['_static']
+html_title = "Ansible SDK Documentation"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,14 +15,8 @@ release = '0.0.1'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    'sphinx_immaterial',
-    'sphinx_immaterial.apidoc.python.apigen'
+     'sphinx_ansible_theme',
 ]
-
-python_apigen_modules = {
-      "ansible_sdk": "api/",
-      "ansible_sdk.executors": "api/executors/"
-}
 
 templates_path = ['_templates']
 exclude_patterns = []
@@ -31,5 +25,5 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_immaterial'
+html_theme = 'sphinx_ansible_theme'
 html_static_path = ['_static']

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,9 @@ commands = pytest {posargs:tests/unit}
 [testenv:docs]
 description = Build documentation
 deps = -r{toxinidir}/docs/doc-requirements.txt
-commands = sphinx-build -T -E -W -n --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs/source docs/build/html
+commands = 
+  sphinx-apidoc -o docs/source/api ansible_sdk
+  sphinx-build -T -E -W -n --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs/source docs/build/html
 
 [testenv:integration{,-py38,-py39,-py310,-py311}]
 description = Run integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ description = Build documentation
 deps = -r{toxinidir}/docs/doc-requirements.txt
 commands = 
   sphinx-apidoc -o docs/source/api ansible_sdk
-  sphinx-build -T -E -W -n --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs/source docs/build/html
+  sphinx-build -T -E -n --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs/source docs/build/html
 
 [testenv:integration{,-py38,-py39,-py310,-py311}]
 description = Run integration tests


### PR DESCRIPTION
##### SUMMARY

* sphinx-ansible-theme is used by other ansible project such as ansible-lint
  let us switch to sphinx-ansible-theme for now
* fixed ``tox -e docs`` in CI

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/doc-requirements.txt
docs/source/api.rst
docs/source/conf.py
