### PR TITLE
Docs: Autogenerate API reference content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,5 @@ cython_debug/
 docs/build/
 # generated content
 docs/source/api/
+docs/api_reference/api
 .DS_Store

--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -1,0 +1,53 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'ansible-sdk'
+copyright = '2022, Ansible'
+author = 'Ansible'
+release = '0.0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx_immaterial',
+    'sphinx_immaterial.apidoc.python.apigen'
+]
+
+python_apigen_modules = {
+      "ansible_sdk": "api/",
+      "ansible_sdk.executors": "api/executors/"
+}
+
+# Temporarily ignore "missing reference" warnings with apidoc generation.
+nitpicky = True
+nitpick_ignore = [
+    ('py:class', 'ansible_sdk.executors.base.AnsibleJobExecutorOptionsBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk._util.dataclass_compat._DataclassReplaceMixin'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk._util.dataclass_compat._DataclassReplaceMixin'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess.OptionsT'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk.executors.mesh.AnsibleMeshJobOptions'),
+]
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = "ansible"
+highlight_language = "YAML+Jinja"
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_immaterial'
+html_title = "Ansible SDK API Reference"

--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -15,9 +15,14 @@ release = '0.0.1'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    'sphinx.ext.intersphinx',
     'sphinx_immaterial',
     'sphinx_immaterial.apidoc.python.apigen'
 ]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}
 
 python_apigen_modules = {
       "ansible_sdk": "api/",

--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -1,0 +1,6 @@
+Ansible SDK API Reference
+=========================
+
+Reference documenation for the Ansible SDK API.
+
+.. python-apigen-group:: Classes

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,3 @@
 Sphinx==5.1.1
 sphinx-ansible-theme==0.9.1
-sphinxcontrib-apidoc==0.3.0
+sphinx-immaterial==0.9.1

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,5 +1,5 @@
-API Reference
-=============
+Ansible SDK API
+===============
 
-.. python-apigen-group:: Classes
+Visit the :api_reference:`Ansible SDK API Reference<api/index.html>`
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,5 +1,6 @@
 Ansible SDK API
 ===============
 
-Visit the :api_reference:`Ansible SDK API Reference<api/index.html>`
+The Ansible SDK API exposes classes in a public `ansible_sdk.*` namespace.
 
+For documentation on all public classes and their functions, see the :api_reference:`Ansible SDK API Reference<api/index.html>`.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,8 +1,5 @@
 API Reference
 =============
 
-.. toctree::
-
-   api/modules
-   api/executors
+.. python-apigen-group:: Classes
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,8 @@ release = '0.0.1'
 extensions = [
     'sphinx.ext.intersphinx',
     'sphinx_ansible_theme',
-    'sphinxcontrib.apidoc'
+    'sphinx_immaterial',
+    'sphinx_immaterial.apidoc.python.apigen'
 ]
 
 intersphinx_mapping = {
@@ -37,6 +38,24 @@ source_suffix = {
     ".rst": "restructuredtext",
     ".md": "markdown",
 }
+
+# Temporarily ignore "missing reference" warnings with apidoc generation.
+nitpicky = True
+nitpick_ignore = [
+    ('py:class', 'ansible_sdk.executors.base.AnsibleJobExecutorOptionsBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk._util.dataclass_compat._DataclassReplaceMixin'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk._util.dataclass_compat._DataclassReplaceMixin'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess.OptionsT'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk.executors.mesh.AnsibleMeshJobOptions'),
+]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "ansible"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,47 +15,14 @@ release = '0.0.1'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    'sphinx.ext.intersphinx',
-    'sphinx_ansible_theme',
-    'sphinx_immaterial',
-    'sphinx_immaterial.apidoc.python.apigen'
+    'sphinx.ext.extlinks',
+    'sphinx_ansible_theme'
 ]
 
-intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-}
+extlinks = {'api_reference': ('./%s', None)}
 
 templates_path = ['_templates']
 exclude_patterns = []
-
-#apidoc configuration
-#find more at https://pypi.org/project/sphinxcontrib-apidoc/
-apidoc_module_dir = '../../ansible_sdk/'
-#apidoc_excluded_paths = ['tests']
-apidoc_separate_modules = True
-
-source_suffix = {
-    ".rst": "restructuredtext",
-    ".md": "markdown",
-}
-
-# Temporarily ignore "missing reference" warnings with apidoc generation.
-nitpicky = True
-nitpick_ignore = [
-    ('py:class', 'ansible_sdk.executors.base.AnsibleJobExecutorOptionsBase'),
-    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
-    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
-    ('py:class', 'ansible_sdk._util.dataclass_compat._DataclassReplaceMixin'),
-    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
-    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
-    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
-    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
-    ('py:class', 'ansible_sdk._util.dataclass_compat._DataclassReplaceMixin'),
-    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
-    ('py:class', 'ansible_sdk.executors.subprocess.OptionsT'),
-    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
-    ('py:class', 'ansible_sdk.executors.mesh.AnsibleMeshJobOptions'),
-]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "ansible"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,9 +15,9 @@ Ansible SDK is a toolkit that lets you harness the power and simplicity of Ansib
    api
 
 .. Uncomment these lines when content is in place.
-..Indices and tables
-..==================
+.. Indices and tables
+.. ==================
 
-..* :ref:`genindex`
-..* :ref:`modindex`
-..* :ref:`search`
+.. * :ref:`genindex`
+.. * :ref:`modindex`
+.. * :ref:`search`

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,8 @@ commands = pytest {posargs:tests/unit}
 description = Build documentation
 deps = -r{toxinidir}/docs/doc-requirements.txt
 commands = 
-  sphinx-apidoc -o docs/source/api ansible_sdk
-  sphinx-build -T -E -n --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs/source docs/build/html
+  sphinx-build -T -E -n -c docs/api_reference --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs/api_reference docs/build/html/api
+  sphinx-build -T -E -n -c docs/source --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs/source docs/build/html
 
 [testenv:integration{,-py39,-py310,-py311}]
 description = Run integration tests


### PR DESCRIPTION
This PR uses the immaterial extension with Sphinx to generate API docs.

To do:
- Find a fix for the warnings that are ignored in by nitpicky in conf.py
- Fix additional warnings during tox build.