### PR TITLE
add intersphinx to docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,9 +15,14 @@ release = '0.0.1'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    'sphinx.ext.intersphinx',
     'sphinx_ansible_theme',
     'sphinxcontrib.apidoc'
 ]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}
 
 templates_path = ['_templates']
 exclude_patterns = []


### PR DESCRIPTION
Adds the [intersphinx extension](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) to docs and adds a mapping for Python standard library docu