### PR TITLE
fix default bindaddr in mesh example config

### DIFF
--- a/examples/receptor_config/foo.yml
+++ b/examples/receptor_config/foo.yml
@@ -3,6 +3,7 @@
     id: foo
 
 - tcp-listener:
+    bindaddr: 127.0.0.1
     port: 2222
 
 - control-service:


### PR DESCRIPTION
* receptor network socket listeners default to `::` (ipv6-aware version of `0.0.0.0`, ie, all adapters). Since this example runs entirely locally, no need to expose an unauthenticated ability to run ansible jobs as the current user to anyone that can reach the box...