### PR TITLE
Docs: fix comments in docs index

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,9 +15,9 @@ Ansible SDK is a toolkit that lets you harness the power and simplicity of Ansib
    api
 
 .. Uncomment these lines when content is in place.
-..Indices and tables
-..==================
+.. Indices and tables
+.. ==================
 
-..* :ref:`genindex`
-..* :ref:`modindex`
-..* :ref:`search`
+.. * :ref:`genindex`
+.. * :ref:`modindex`
+.. * :ref:`search`


### PR DESCRIPTION
For some reason the bits in the index are not commented correctly and result in error.