### PR TITLE
Docs: use sphinx ansible theme and contrib-apidoc

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,8 +1,10 @@
 API Reference
 =============
 
+The Ansible SDK API exposes classes in a public `ansible_sdk.*` namespace.
+
 .. toctree::
+   :maxdepth: 2
 
    api/modules
-   api/executors
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,24 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
 }
 
+# Temporarily ignore "missing reference" warnings with apidoc generation.
+nitpicky = True
+nitpick_ignore = [
+    ('py:class', 'ansible_sdk.executors.base.AnsibleJobExecutorOptionsBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk._util.dataclass_compat._DataclassReplaceMixin'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk._util.dataclass_compat._DataclassReplaceMixin'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobExecutorBase'),
+    ('py:class', 'ansible_sdk.executors.subprocess.OptionsT'),
+    ('py:class', 'ansible_sdk.executors.subprocess._AnsibleContainerJobOptions'),
+    ('py:class', 'ansible_sdk.executors.mesh.AnsibleMeshJobOptions')
+]
+
 templates_path = ['_templates']
 exclude_patterns = []
 
@@ -32,11 +50,6 @@ exclude_patterns = []
 apidoc_module_dir = '../../ansible_sdk/'
 #apidoc_excluded_paths = ['tests']
 apidoc_separate_modules = True
-
-source_suffix = {
-    ".rst": "restructuredtext",
-    ".md": "markdown",
-}
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "ansible"

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ description = Build documentation
 deps = -r{toxinidir}/docs/doc-requirements.txt
 commands = 
   sphinx-apidoc -o docs/source/api ansible_sdk
-  sphinx-build -T -E -n --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs/source docs/build/html
+  sphinx-build -T -E -W -n --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs/source docs/build/html
 
 [testenv:integration{,-py39,-py310,-py311}]
 description = Run integration tests


### PR DESCRIPTION
Use the Sphinx Ansible theme and the sphinxcontrib.apidoc extension for docs.