### PR TITLE
Docs: Fix RTD apidoc

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,4 +25,6 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
+    - method: pip
+      path: .
     - requirements: docs/doc-requirements.txt

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,6 +5,7 @@ The Ansible SDK API exposes classes in a public `ansible_sdk.*` namespace.
 
 .. toctree::
    :maxdepth: 2
+   :glob:
 
-   api/modules
+   api/*
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,8 +48,10 @@ exclude_patterns = []
 #apidoc configuration
 #find more at https://pypi.org/project/sphinxcontrib-apidoc/
 apidoc_module_dir = '../../ansible_sdk/'
-#apidoc_excluded_paths = ['tests']
+apidoc_output_dir = 'api'
 apidoc_separate_modules = True
+apidoc_toc_file = False
+apidoc_module_first = True
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "ansible"

--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,7 @@ commands = pytest {posargs:tests/unit}
 [testenv:docs]
 description = Build documentation
 deps = -r{toxinidir}/docs/doc-requirements.txt
-commands = 
-  sphinx-apidoc -o docs/source/api ansible_sdk
+commands =
   sphinx-build -T -E -W -n --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs/source docs/build/html
 
 [testenv:integration{,-py39,-py310,-py311}]


### PR DESCRIPTION
This PR fixes the empty content in https://ansible-sdk.readthedocs.io/en/latest/api.html

Need to update the RTD config to install the project so the build process can find the modules and generate API reference content correctly.

Also makes some changes to improve usage of the `sphinxcontrib.apidoc` extension. We can drop the apidoc command and put those settings in `conf.py` and use the `glob` directive in the API reference index, which is a little nicer than the generated modules TOC imo.

