### PR TITLE
Remove mock outputs and add quiet parameter

### DIFF
--- a/ansible_sdk/executors/base.py
+++ b/ansible_sdk/executors/base.py
@@ -32,30 +32,19 @@ class AnsibleJobExecutorBase(abc.ABC):
                 raise Exception('empty line received; unexpected EOF')
 
             data = await async_json.loads(line)
-            # print(f'decoded json, got keys {data.keys()}')
-
-            # print(f'got a line of length {len(line)}')
 
             if 'event' in data:
-                # print(f'appending event of type {data["event"]}')
                 status_obj._add_event(data)
             elif 'zipfile' in data:
-                # print(f'zipfile coming, {data["zipfile"]} bytes expected')
                 zf = await reader.readline()
                 # FIXME: handle returned artifacts
-                # print(f'received {len(zf)} raw bytes (and discarded)')
-
                 # FIXME: is this a bug?
                 if b'{"eof": true}' in zf:
-                    # print('eof was embedded in zip line, done with stream_events')
                     break
             elif 'eof' in data:
-                # print('got eof, done with stream_events')
                 break
             elif 'status' in data:
                 # FIXME: propagate to status object
-                # print(f'got status blob: {line[0:100]} ... ')
                 pass
             else:
-                # print('\n\n*** unexpected data... ***\n\n')
                 pass

--- a/ansible_sdk/executors/mesh.py
+++ b/ansible_sdk/executors/mesh.py
@@ -54,12 +54,10 @@ class AnsibleMeshJobExecutor(AnsibleJobExecutorBase):
             unit_id = self._running_job_info[status_obj].unit_id
             try:
                 async with ReceptorControlAsync.create_ctx(status_obj._executor_options.control_socket_url) as rc:
-                    print(f'releasing work unit_id {unit_id}')
                     await rc.simple_command_async(f'work force-release {unit_id}')
-                    print(f'released work unit_id {unit_id}')
-            except Exception as ex:
+            except Exception:
                 # FIXME: log and propagate to status object
-                print(f'error releasing work unit_id {unit_id}: {str(ex)}')
+                pass
 
     async def submit_job(self, job_def: AnsibleJobDef, options: AnsibleMeshJobOptions) -> AnsibleJobStatus:
         loop = asyncio.get_running_loop()
@@ -70,10 +68,8 @@ class AnsibleMeshJobExecutor(AnsibleJobExecutorBase):
             payload_builder = asyncio.create_task(asyncio_write_payload_and_close(payload_writer=payload_writer, **self._get_runner_args(job_def, options)))
 
             async with ReceptorControlAsync.create_ctx(options.control_socket_url) as rc:
-                print('submitting work')
                 work_submission = await rc.submit_work_async('ansible-runner', payload=payload_reader, node=options.target_node)
                 work_unit_id: str = work_submission['unitid']
-                print(f'work submitted, unit_id {work_unit_id}')
 
                 # FIXME: it's poor form to fire-and-forget in case there's a failure on the payload builder (which could theoretically result
                 #  in a truncated or forever-blocked work submission), but we can't await before submission starts, since a large
@@ -81,16 +77,13 @@ class AnsibleMeshJobExecutor(AnsibleJobExecutorBase):
                 #  file-like that would allow for a more asyncio-native solution. Also think through how we'd recover a failure at this
                 #  point, since the work has already been submitted with a potentially bad payload.
                 await payload_builder
-                print('payload builder completed ok')
 
         result_socket: socket.socket
         sockfile: io.FileIO
 
         # BUG: setting return_sockfile False fails in receptorctl (access to misnamed instance attr trying to close the sockfile)
         async with ReceptorControlAsync.create_ctx(options.control_socket_url) as rc:
-            print('getting results')
             result_socket, sockfile = await rc.get_work_results_async(work_unit_id, return_socket=True, return_sockfile=True)
-            print('got results')
 
         # mimic what the client would do if return_sockfile weren't broken
         sockfile.close()

--- a/ansible_sdk/executors/subprocess.py
+++ b/ansible_sdk/executors/subprocess.py
@@ -64,7 +64,6 @@ class AnsibleSubprocessJobExecutor(AnsibleJobExecutorBase):
         # start payload creation first by explicitly creating a task; this will start feeding our pipe now
         payload_builder = asyncio.create_task(asyncio_write_payload_and_close(payload_writer=payload_writer, **self._get_runner_args(job_def, options)))
 
-        # print('starting worker')
         runner_args = self._get_runner_args(job_def, options)
 
         # FIXME: this prevents pollution of the original datadir for local runs and returned artifacts;
@@ -81,16 +80,13 @@ class AnsibleSubprocessJobExecutor(AnsibleJobExecutorBase):
             _output=results_writer,
             cancel_callback=cancel_partial,
             **runner_args))
-        # print('worker running')
 
         # FIXME: it's poor form to fire-and-forget in case there's a failure on the payload builder (which could theoretically result
         #  in a truncated or forever-blocked work submission), but we can't await before submission starts, since a large
         #  payload can't be completely written before consumption begins. Look into things like aiozipstream and a lighter-weight
         #  file-like that would allow for a more asyncio-native solution. Also think through how we'd recover a failure at this
         #  point, since the work has already been submitted with a potentially bad payload.
-        # print('awaiting payload builder')
         await payload_builder
-        # print('payload builder completed ok')
 
         # FIXME: small line-length limit is problematic with large stdout and zip payloads;
         #  the latter can be handled with an explicit chunked read + copy to disk until separator or

--- a/ansible_sdk/model/job_def.py
+++ b/ansible_sdk/model/job_def.py
@@ -27,3 +27,4 @@ class AnsibleJobDef(_DataclassReplaceMixin):
     inventory: t.Optional[t.Union[str, list[str]]] = None  # FUTURE: high-level inventory types?
     extra_vars: dict[str, t.Any] = field(default_factory=dict)
     verbosity: t.Optional[int] = None  # None or 1-5
+    quiet: t.Optional[bool] = False

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -13,26 +13,13 @@ async def main(job_options={}):
 
     job_status = await executor.submit_job(jobdef, AnsibleSubprocessJobOptions())
 
-    # consume events and accumulate stdout replica
-    stdout = ''
-
     # consume events as they arrive
     eventcount = 0
     async for ev in job_status.events:
         eventcount += 1
-        print(f'*** consumed event {ev}')
-
-    print(f'event enumeration completed, total {eventcount}')
-
-    print(f'stdout results: {stdout}')
 
     # directly await the job object
-    print('*** directly awaiting the job status...')
     await job_status
-
-    print(f'event count: {len(job_status._events)}')
-
-    print('all done, exiting')
 
 
 def test_basic(datadir):


### PR DESCRIPTION
This commit implements the `quiet` parameter of runner that was requested to be ported to the SDK. I looked through the code and found only output to stdout that was used for development. Removed it.

Quiet option in jobs can be used in the future to decide if informal output should be done at all.