### PR TITLE
Add support for ident parameter

### DIFF
--- a/ansible_sdk/executors/subprocess.py
+++ b/ansible_sdk/executors/subprocess.py
@@ -40,6 +40,7 @@ class AnsibleSubprocessJobExecutor(AnsibleJobExecutorBase):
             'extravars': job_def.extra_vars,
             'verbosity': job_def.verbosity,
             'limit': job_def.limit,
+            'ident': job_def.ident,
         }
 
         return args

--- a/ansible_sdk/model/job_def.py
+++ b/ansible_sdk/model/job_def.py
@@ -18,12 +18,15 @@ class AnsibleJobDef(_DataclassReplaceMixin):
     :param extra_vars: dictionary of variables for highest precedence level, analogue to Ansible's ``-e`` option
     :param verbosity: None for default verbosity or 1-5, equivalent to Ansible's ``-v`` options
     :param limit: Matches Ansible's ``--limit`` parameter to further constrain the inventory to be used
+    :param ident: The run identifier for this invocation of Runner. Will be used to create and name
+                  the artifact directory holding the results of the invocation.
     """
     # currently analogue to runner's private_data_dir; do we want to construct this ourselves?
     data_dir: str
     # relative path to playbook in data_dir or FQCN
     playbook: str
     limit: str = None
+    ident: str = None
     inventory: t.Optional[t.Union[str, list[str]]] = None  # FUTURE: high-level inventory types?
     extra_vars: dict[str, t.Any] = field(default_factory=dict)
     verbosity: t.Optional[int] = None  # None or 1-5

--- a/examples/example_common.py
+++ b/examples/example_common.py
@@ -10,8 +10,10 @@ async def run_one_stdout(executor, executor_options, job_options={}):
     playbook = job_options.get('playbook', 'pb.yml')
     datadir = job_options.get('datadir', 'datadir')
     limit = job_options.get('limit', None)
+    ident = job_options.get('ident', None)
+
     try:
-        job_def = AnsibleJobDef(data_dir=datadir, playbook=playbook, limit=limit)
+        job_def = AnsibleJobDef(data_dir=datadir, playbook=playbook, limit=limit, ident=ident)
         job_status = await executor.submit_job(job_def, executor_options)
 
         async for line in job_status.stdout_lines:
@@ -32,8 +34,10 @@ async def run_one_events(executor, executor_options, job_options={}):
     playbook = job_options.get('playbook', 'pb.yml')
     datadir = job_options.get('datadir', 'datadir')
     limit = job_options.get('limit', None)
+    ident = job_options.get('ident', None)
+
     try:
-        job_def = AnsibleJobDef(data_dir=datadir, playbook=playbook, limit=limit)
+        job_def = AnsibleJobDef(data_dir=datadir, playbook=playbook, limit=limit, ident=ident)
         job_status = await executor.submit_job(job_def, executor_options)
 
         eventcount = 0
@@ -58,8 +62,10 @@ async def run_many(executor, executor_options, job_options={}):
     playbook = job_options.get('playbook', 'pb.yml')
     datadir = job_options.get('datadir', 'datadir')
     limit = job_options.get('limit', None)
+    ident = job_options.get('ident', None)
+
     try:
-        job_def = AnsibleJobDef(data_dir=datadir, playbook=playbook, limit=limit)
+        job_def = AnsibleJobDef(data_dir=datadir, playbook=playbook, limit=limit, ident=ident)
 
         num_jobs = 5
 

--- a/examples/example_subprocess_ident.py
+++ b/examples/example_subprocess_ident.py
@@ -1,0 +1,19 @@
+import asyncio
+
+
+from ansible_sdk.executors import AnsibleSubprocessJobExecutor, AnsibleSubprocessJobOptions
+from example_common import run_one_stdout
+
+
+async def main():
+    executor = AnsibleSubprocessJobExecutor()
+    executor_options = AnsibleSubprocessJobOptions()
+    job_options = {
+        'ident': 'sample_dir'
+    }
+
+    await run_one_stdout(executor, executor_options, job_options)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -52,3 +52,13 @@ def test_limit(datadir):
         'limit': 'h1',
     }
     asyncio.run(main(job_options))
+
+
+def test_ident(datadir):
+    example_dir = str(datadir / 'basic')
+    job_options = {
+        'datadir': example_dir,
+        'playbook': 'pb.yml',
+        'ident': 'sample_dir',
+    }
+    asyncio.run(main(job_options))


### PR DESCRIPTION
##### SUMMARY

* Added support for parameter `ident` from run API

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible_sdk/executors/subprocess.py
ansible_sdk/model/job_def.py
examples/example_common.py
examples/example_subprocess_ident.py
tests/integration/test_basic.py
