### PR TITLE
fix job event wrapper

### DIFF
--- a/ansible_sdk/__init__.py
+++ b/ansible_sdk/__init__.py
@@ -1,7 +1,7 @@
 from .model.job_def import AnsibleJobDef
-from .model.job_event import AnsibleJobStatusEvent
+from .model.job_event import AnsibleJobEvent
 from .model.job_status import AnsibleJobStatus
 
-__all__ = ('AnsibleJobDef', 'AnsibleJobStatusEvent', 'AnsibleJobStatus',)
+__all__ = ('AnsibleJobDef', 'AnsibleJobEvent', 'AnsibleJobStatus',)
 
 __version__ = '0.0.1'

--- a/ansible_sdk/executors/base.py
+++ b/ansible_sdk/executors/base.py
@@ -7,8 +7,8 @@ import abc
 import asyncio
 import json as async_json
 
-from ansible_sdk import AnsibleJobStatus, AnsibleJobDef
-from ansible_sdk._aiocompat.proxy import AsyncProxy
+from .. import AnsibleJobStatus, AnsibleJobDef, AnsibleJobEvent
+from .._aiocompat.proxy import AsyncProxy
 
 
 # wrap these modules in an AsyncProxy so they're asyncio-friendly
@@ -36,9 +36,10 @@ class AnsibleJobExecutorBase(abc.ABC):
 
             # print(f'got a line of length {len(line)}')
 
-            if 'event' in data:
+            if event_name := data.get('event'):
                 # print(f'appending event of type {data["event"]}')
-                status_obj._add_event(data)
+                wrapped_data = AnsibleJobEvent(name=event_name, raw_event_data=data)
+                status_obj._add_event(wrapped_data)
             elif 'zipfile' in data:
                 # print(f'zipfile coming, {data["zipfile"]} bytes expected')
                 zf = await reader.readline()

--- a/ansible_sdk/model/job_event.py
+++ b/ansible_sdk/model/job_event.py
@@ -1,27 +1,38 @@
 # Copyright: Ansible Project
 # Apache License 2.0 (see LICENSE or https://www.apache.org/licenses/LICENSE-2.0)
-
 from __future__ import annotations
 
+import typing as t
+
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 
 @dataclass
-class AnsibleJobStatusEvent:
+class AnsibleJobEvent(Mapping):
     """
     Container object for various Ansible events.
 
-    :param event: name of the event type
-    :param event_data: dictionary of the raw event data
+    :param name: name of the event type
+    :param raw_event_data: dictionary of the raw event data
     :param stdout: display text output associated with this event (if any)
     """
-    uuid: str
-    parent_uuid: str
-    counter: int
-    stdout: str
-    start_line: int
-    end_line: int
-    event: str
-    event_data: dict
-    pid: int
-    created: str
+    name: str
+    raw_event_data: dict[str, t.Any]
+
+    # static no-op impls to keep type-checking happy; we'll patch these during construction
+    # FIXME: these shouldn't be necessary to truly implement
+    def __getitem__(self, item):
+        return self.raw_event_data.__getitem__(item)
+
+    def __iter__(self):
+        return self.raw_event_data.__iter__()
+
+    def __len__(self):
+        return self.raw_event_data.__len__()
+
+    # def __post_init__(self):
+    #     # patch event dict mapping impl methods directly through
+    #     self.__getitem__ = self.raw_event_data.__getitem__
+    #     self.__iter__ = self.raw_event_data.__iter__
+    #     self.__len__ = self.raw_event_data.__len__

--- a/ansible_sdk/model/job_status.py
+++ b/ansible_sdk/model/job_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import typing as t
 
-from .job_event import AnsibleJobStatusEvent
+from .job_event import AnsibleJobEvent
 from .job_def import AnsibleJobDef
 
 
@@ -23,13 +23,13 @@ class AnsibleJobStatus:
         self._runner_status = None  # stash the runner status object here and consult it on completion for errors, etc
         self._job_def = job_def
 
-    def _add_event(self, evt: AnsibleJobStatusEvent):
+    def _add_event(self, evt: AnsibleJobEvent):
         self._events.append(evt)
         # pulse the appended event to awaken any blocked iterators
         self._events_appended.set()
         self._events_appended.clear()
 
-    def drop_event(self, evt: AnsibleJobStatusEvent):
+    def drop_event(self, evt: AnsibleJobEvent):
         """
         Request discard of event data that is no longer needed.
 
@@ -38,13 +38,13 @@ class AnsibleJobStatus:
         self._events[self._events.index(evt)] = None
 
     @property
-    async def events(self) -> t.AsyncIterator[AnsibleJobStatusEvent]:
+    async def events(self) -> t.AsyncIterator[AnsibleJobEvent]:
         """
         Async iterator to enumerate events from this job. Events are yielded live while the job is running; the
         iterator will not complete until the job has completed or failed. In cases of job failure or cancellation,
         the iterator will raise an exception with the appropriate detail.
 
-        :return: a live iterator of ``AnsibleJobStatusEvent`` data for this job
+        :return: a live iterator of ``AnsibleJobEvent`` data for this job
         """
         cur_ev_idx = 0
         streaming_complete = False

--- a/tests/unit/test_job_event.py
+++ b/tests/unit/test_job_event.py
@@ -1,27 +1,13 @@
 from datetime import datetime
 
-from ansible_sdk.model.job_event import AnsibleJobStatusEvent
+from ansible_sdk.model.job_event import AnsibleJobEvent
 
 
-class TestAnsibleJobStatusEvent:
+class TestAnsibleJobEvent:
     def test_status(self):
         ts = datetime(2022, 12, 31, 7, 59, 30, 1234).isoformat()
         data = {"yes": "maybe"}
-        event = AnsibleJobStatusEvent(uuid="theUUID", parent_uuid="theParentUUID", counter=1,
-                                      stdout="theStdout", start_line=0, end_line=10,
-                                      event="theEvent", event_data=data, pid=42, created=ts)
-        assert event.uuid == "theUUID"
-        assert event.parent_uuid == "theParentUUID"
-        assert event.counter == 1
-        assert event.stdout == "theStdout"
-        assert event.start_line == 0
-        assert event.end_line == 10
-        assert event.event == "theEvent"
-        assert event.event_data == data
-        assert event.pid == 42
-        assert event.created == ts
-
-        # Test setting new created timestamp
-        new_ts = datetime(2000, 1, 17, 14, 00, 13, 5678).isoformat()
-        event.created = new_ts
-        assert event.created == new_ts
+        event = AnsibleJobEvent(name="theEvent", raw_event_data=data)
+        assert event.name == "theEvent"
+        assert event.raw_event_data == data
+        assert event['yes'] == 'maybe'  # direct indexing should pass through to raw_event_data

--- a/tests/unit/test_job_event.py
+++ b/tests/unit/test_job_event.py
@@ -5,7 +5,6 @@ from ansible_sdk.model.job_event import AnsibleJobEvent
 
 class TestAnsibleJobEvent:
     def test_status(self):
-        ts = datetime(2022, 12, 31, 7, 59, 30, 1234).isoformat()
         data = {"yes": "maybe"}
         event = AnsibleJobEvent(name="theEvent", raw_event_data=data)
         assert event.name == "theEvent"

--- a/tests/unit/test_job_event.py
+++ b/tests/unit/test_job_event.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from ansible_sdk.model.job_event import AnsibleJobEvent
 
 


### PR DESCRIPTION
There was some back and forth awhile back on how `dict`-ish the job event should be- at some point it got messed up and actually turned into *just* a `dict`, which was never the intent. Restore it to a wrapped type that just passes through a `Mapping` impl to the underlying `raw_event_data` (also renamed the event type and removed most of the fields for now since they're not always applicable and pretty specific to runner/AAP internals).