### PR TITLE
Updated sanity test with pylint

### DIFF
--- a/ansible_sdk/_aiocompat/csv_async.py
+++ b/ansible_sdk/_aiocompat/csv_async.py
@@ -2,8 +2,10 @@
 # Apache License 2.0 (see LICENSE or https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import annotations
-from .proxy import AsyncProxy
+
 from csv import DictWriter
+
+from .proxy import AsyncProxy
 
 
 class CSVAsync(DictWriter):

--- a/ansible_sdk/_aiocompat/proxy.py
+++ b/ansible_sdk/_aiocompat/proxy.py
@@ -8,7 +8,7 @@ from types import ModuleType
 
 
 # hacky threadpool proxy wrapper around modules, adapted from http://zderadicka.eu/asyncio-proxy-for-blocking-functions/
-class AsyncProxy(object):
+class AsyncProxy:
     def __init__(self, wrapped):
         self._wrapped = wrapped
 

--- a/ansible_sdk/_aiocompat/receptorctl_async.py
+++ b/ansible_sdk/_aiocompat/receptorctl_async.py
@@ -2,10 +2,13 @@
 # Apache License 2.0 (see LICENSE or https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import annotations
-from .proxy import AsyncProxy
+
 from collections.abc import Iterator
 from contextlib import asynccontextmanager
+
 from receptorctl import ReceptorControl
+
+from .proxy import AsyncProxy
 
 
 class ReceptorControlAsync(ReceptorControl):

--- a/ansible_sdk/_aiocompat/runner_async.py
+++ b/ansible_sdk/_aiocompat/runner_async.py
@@ -1,9 +1,9 @@
 # Copyright: Ansible Project
 # Apache License 2.0 (see LICENSE or https://www.apache.org/licenses/LICENSE-2.0)
 
-from .proxy import AsyncProxy
-
 from ansible_runner.interface import run as _run
+
+from .proxy import AsyncProxy
 
 
 def _write_payload_and_close(payload_writer, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,39 @@ doc = ["sphinx"]
 
 [tool.setuptools.dynamic]
 version = {attr = "ansible_sdk.__version__"}
+
+[tool.pylint.main]
+output-format = "colorized"
+max-line-length=120
+disable = [
+  "all",
+
+  # Some codes we will leave disabled
+  "C0103",  # invalid-name
+  "C0114",  # missing-module-docstring
+  "C0115",  # missing-class-docstring
+  "C0116",  # missing-function-docstring
+
+  "R0902",  # too-many-instance-attributes
+
+  "W1514",  # unspecified-encoding
+]
+
+enable = [
+  "C0206",  # consider-using-dict-items
+  "C0209",  # consider-using-f-string
+  "C0411",  # wrong-import-order
+
+  "E1101",  # no-member
+
+  "R0205",  # useless-object-inheritance
+  "R0402",  # consider-using-from-import
+  "R1705",  # no-else-return
+  "R1725",  # super-with-arguments
+  "R1735",  # use-dict-literal
+
+  "W0102",  # dangerous-default-value
+  "W0707",  # raise-missing-from
+  "W1203",  # logging-fstring-interpolation
+
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
-import pytest
 import shutil
 
 from pathlib import Path
+
+import pytest
 
 
 @pytest.fixture

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -8,7 +8,9 @@ from ansible_sdk.executors import (
 )
 
 
-async def main(job_options={}):
+async def main(job_options=None):
+    if job_options is None:
+        job_options = {}
     executor = AnsibleSubprocessJobExecutor()
     example_dir = job_options.get("datadir")
     playbook = job_options.get("playbook")
@@ -127,7 +129,7 @@ def test_role(datadir):
     file_path = pathlib.Path(__file__).parent.resolve()
     job_options = {
         'role': 'hello_world',
-        'roles_path': '%s/roles' % file_path
+        'roles_path': f'{file_path}/roles'
     }
 
     asyncio.run(main(job_options))

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -5,3 +5,4 @@ flake8
 pytest
 pytest-xdist
 yamllint
+pylint==2.17.4

--- a/tests/unit/_util/test_dataclass_compat.py
+++ b/tests/unit/_util/test_dataclass_compat.py
@@ -1,6 +1,7 @@
 import dataclasses as dataclasses_real
-import pytest
 import typing as t
+
+import pytest
 
 import ansible_sdk._util.dataclass_compat as dataclasses
 
@@ -13,7 +14,9 @@ class TestKWOnlyPolyfill:
             required_str: str
             optional_int: t.Optional[int] = None
 
-        kwargs = dict(required_str='strvalue', optional_int=42)
+        kwargs = {
+            "required_str": 'strvalue', "optional_int": 42
+        }
 
         dc = TestFrozenDC(**kwargs)
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands =
     flake8 ansible_sdk tests
     yamllint --version
     yamllint -s .
+    pylint ansible_sdk tests
 
 [testenv:unit{,-py39,-py310,-py311}]
 description = Run unit tests


### PR DESCRIPTION
##### SUMMARY

* Disable (C0103) invalid-name
* Disable (C0114) missing-module-docstring
* Disable (C0115) missing-class-docstring
* Disable (C0116) missing-function-docstring
* Disable (R0902) too-many-instance-attributes
* Disable (W1514) unspecified-encoding
* Enable (C0206) consider-using-dict-items
* Enable (C0209) consider-using-f-string
* Enable (C0411) wrong-import-order
* Enable (E1101) no-member
* Enable (R0205) useless-object-inheritance
* Enable (R0402) consider-using-from-import
* Enable (R1705) no-else-return
* Enable (R1725) super-with-arguments
* Enable (R1735) use-dict-literal
* Enable (W0102) dangerous-default-value
* Enable (W0707) raise-missing-from
* Enable (W1203) logging-fstring-interpolation

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
ansible_sdk/_aiocompat/csv_async.py
ansible_sdk/_aiocompat/proxy.py
ansible_sdk/_aiocompat/receptorctl_async.py
ansible_sdk/_aiocompat/runner_async.py
pyproject.toml
tests/conftest.py
tests/integration/test_basic.py
tests/unit/_util/test_dataclass_compat.py
tox.ini

