### PR TITLE
Docsite: add Community guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,7 @@ This section assumes that you have configured the following git remotes for your
 
 We welcome community contributions to this repo. If you find problems, please open an issue or create a PR against the [repo](https://github.com/ansible/ansible-sdk/issues/new).
 
-You can also join us on:
-
-- IRC - the ``#ansible-devel`` [irc.libera.chat](https://libera.chat/) channel
-
-See the [Ansible Community Guide](https://docs.ansible.com/ansible/latest/community/index.html) for details on contributing to Ansible.
-
+Need help or want to discuss Ansible SDK including the documentation? See our [Community guide](https://ansible.readthedocs.io/projects/sdk/en/latest/community.html) to learn how to join the conversation! 
 
 ## License
 

--- a/docs/source/community.rst
+++ b/docs/source/community.rst
@@ -22,4 +22,4 @@ Join the `Ansible Forum <https://forum.ansible.com>`_, the default communication
 * `Social Spaces <https://forum.ansible.com/c/chat/4>`_: gather and interact with fellow enthusiasts.
 * `News & Announcements <https://forum.ansible.com/c/news/5>`_: track project-wide announcements including social events.
 
-For more information on the forum navigation, see `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ post.
+See `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ for some practical advice on finding your way around.

--- a/docs/source/community.rst
+++ b/docs/source/community.rst
@@ -1,0 +1,25 @@
+.. _community:
+
+Community
+=========
+
+We welcome your feedback, questions and ideas. Here's how to reach the community.
+
+Code of Conduct
+---------------
+
+All communication and interactions in the Ansible community are governed by the `Ansible code of conduct <https://docs.ansible.com/ansible/devel/community/code_of_conduct.html>`_. Please read and abide by it!
+Reach out to our community team at `codeofconduct@ansible.com <mailto:codeofconduct@ansible.com>`_ if you have any questions or need assistance.
+
+Ansible Forum
+-------------
+
+Join the `Ansible Forum <https://forum.ansible.com>`_, the default communication platform for questions and help, development discussions, events, and much more. `Register <https://forum.ansible.com/signup?>`_ to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
+
+* `Get Help <https://forum.ansible.com/c/help/6>`_: get help or help others. Please add appropriate tags if you start new discussions, for example `ansible-sdk`.
+* `Posts tagged with 'ansible-sdk' <https://forum.ansible.com/tag/ansible-sdk>`_: subscribe to participate in project-related conversations.
+* `Bullhorn newsletter <https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn>`_: used to announce releases and important changes.
+* `Social Spaces <https://forum.ansible.com/c/chat/4>`_: gather and interact with fellow enthusiasts.
+* `News & Announcements <https://forum.ansible.com/c/news/5>`_: track project-wide announcements including social events.
+
+For more information on the forum navigation, see `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ post.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,10 @@ Ansible SDK documentation
 
 Ansible SDK is a toolkit that lets you harness the power and simplicity of Ansible automation directly from your applications.
 
+.. note::
+
+  Need help or want to discuss Ansible SDK including the documentation? See the :ref:`Community guide<community>` to learn how to join the conversation!
+
 .. toctree::
    :maxdepth: 1
    :caption: Table of contents:
@@ -13,6 +17,7 @@ Ansible SDK is a toolkit that lets you harness the power and simplicity of Ansib
    running_mesh_jobs
    troubleshooting
    api
+   community
 
 .. Uncomment these lines when content is in place.
 .. Indices and tables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Ansible SDK is a toolkit that lets you harness the power and simplicity of Ansib
 
 .. note::
 
-  Need help or want to discuss all things related to Ansible SDK? See the :ref:`Community guide<community>` and join the conversation!
+   Need help or want to discuss all things related to Ansible SDK? See the :ref:`Community guide<community>` and join the conversation!
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Ansible SDK is a toolkit that lets you harness the power and simplicity of Ansib
 
 .. note::
 
-  Need help or want to discuss Ansible SDK including the documentation? See the :ref:`Community guide<community>` to learn how to join the conversation!
+  Need help or want to discuss all things related to Ansible SDK? See the :ref:`Community guide<community>` and join the conversation!
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thank you